### PR TITLE
customizing -D_GLIBCXX_USE_CXX11_ABI

### DIFF
--- a/package/plugin-llvm-sw-prefetch-no-strides-pass/.cm/info.json
+++ b/package/plugin-llvm-sw-prefetch-no-strides-pass/.cm/info.json
@@ -1,21 +1,21 @@
 {
-  "backup_data_uid": "4339bd3b6b127b43",
-  "backup_module_uid": "1dc07ee0f4742028",
-  "backup_module_uoa": "package",
+  "backup_data_uid": "4339bd3b6b127b43", 
+  "backup_module_uid": "1dc07ee0f4742028", 
+  "backup_module_uoa": "package", 
   "control": {
-    "author": "",
-    "author_email": "",
-    "author_webpage": "",
-    "copyright": "",
-    "engine": "CK",
-    "iso_datetime": "2016-11-19T15:35:07.750211",
-    "license": "",
+    "author": "", 
+    "author_email": "", 
+    "author_webpage": "", 
+    "copyright": "", 
+    "engine": "CK", 
+    "iso_datetime": "2016-11-19T15:35:07.750211", 
+    "license": "", 
     "version": [
-      "1",
-      "8",
-      "4",
+      "1", 
+      "8", 
+      "4", 
       "2"
     ]
-  },
+  }, 
   "data_name": "plugin-llvm-sw-prefetch-no-stides-pass"
 }

--- a/package/plugin-llvm-sw-prefetch-no-strides-pass/.cm/meta.json
+++ b/package/plugin-llvm-sw-prefetch-no-strides-pass/.cm/meta.json
@@ -1,35 +1,36 @@
 {
   "customize": {
-    "env_extra": "_SW_PREFETCH_NO_STRIDES_PASS",
-    "extra_dir": "",
-    "version": "0.1",
+    "env_extra": "_SW_PREFETCH_NO_STRIDES_PASS", 
+    "extra_dir": "", 
     "install_env": {
-      "CK_PLUGIN_OUT": "SwPrefetchPass_noStrides",
-      "CK_NO_STRIDES": "1"
-    }
-  },
+      "CK_NO_STRIDES": "1", 
+      "CK_PLUGIN_OUT": "SwPrefetchPass_noStrides"
+    }, 
+    "version": "0.1"
+  }, 
   "deps": {
     "compiler": {
-      "local": "yes",
-      "name": "C++ compiler",
+      "local": "yes", 
+      "name": "C++ compiler", 
       "tags": "compiler,lang-cpp,llvm,v3.9.0-ck-package"
     }
-  },
+  }, 
   "end_full_path": {
-    "android": "lib$#sep#$SwPrefetchPass_noStrides.so",
-    "linux": "lib/SwPrefetchPass_noStrides.so",
-    "mingw": "lib\\SwPrefetchPass_noStrides.so",
+    "android": "lib$#sep#$SwPrefetchPass_noStrides.so", 
+    "linux": "lib/SwPrefetchPass_noStrides.so", 
+    "mingw": "lib\\SwPrefetchPass_noStrides.so", 
     "win": "lib\\SwPrefetchPass_noStrides.so"
-  },
-  "process_script": "compile",
-  "soft_uoa": "cb5940a8eba4fe8b",
-  "suggested_path": "plugin-llvm-sw-prefetch-no-strides-pass",
+  }, 
+  "need_cpu_info": "yes", 
+  "process_script": "compile", 
+  "soft_uoa": "cb5940a8eba4fe8b", 
+  "suggested_path": "plugin-llvm-sw-prefetch-no-strides-pass", 
   "tags": [
-    "plugin",
-    "compiler-plugin",
-    "llvm",
+    "plugin", 
+    "compiler-plugin", 
+    "llvm", 
     "sw-prefetch-no-strides-pass"
-  ],
+  ], 
   "use_scripts_from_another_entry": {
     "data_uoa": "3468db6b2578ff7d"
   }

--- a/package/plugin-llvm-sw-prefetch-pass/.cm/info.json
+++ b/package/plugin-llvm-sw-prefetch-pass/.cm/info.json
@@ -1,21 +1,21 @@
 {
-  "backup_data_uid": "3468db6b2578ff7d",
-  "backup_module_uid": "1dc07ee0f4742028",
-  "backup_module_uoa": "package",
+  "backup_data_uid": "3468db6b2578ff7d", 
+  "backup_module_uid": "1dc07ee0f4742028", 
+  "backup_module_uoa": "package", 
   "control": {
-    "author": "",
-    "author_email": "",
-    "author_webpage": "",
-    "copyright": "",
-    "engine": "CK",
-    "iso_datetime": "2016-11-18T20:21:48.341962",
-    "license": "",
+    "author": "", 
+    "author_email": "", 
+    "author_webpage": "", 
+    "copyright": "", 
+    "engine": "CK", 
+    "iso_datetime": "2016-11-18T20:21:48.341962", 
+    "license": "", 
     "version": [
-      "1",
-      "8",
-      "4",
+      "1", 
+      "8", 
+      "4", 
       "2"
     ]
-  },
+  }, 
   "data_name": "llvm-plugin-sw-prefetch-pass"
 }

--- a/package/plugin-llvm-sw-prefetch-pass/.cm/meta.json
+++ b/package/plugin-llvm-sw-prefetch-pass/.cm/meta.json
@@ -1,33 +1,34 @@
 {
   "customize": {
-    "extra_dir": "",
-    "env_extra": "_SW_PREFETCH_PASS",
-    "version": "0.1",
+    "env_extra": "_SW_PREFETCH_PASS", 
+    "extra_dir": "", 
     "install_env": {
-      "CK_PLUGIN_OUT": "SwPrefetchPass",
-      "CK_NO_STRIDES": "0"
-    }
-  },
+      "CK_NO_STRIDES": "0", 
+      "CK_PLUGIN_OUT": "SwPrefetchPass"
+    }, 
+    "version": "0.1"
+  }, 
   "deps": {
     "compiler": {
-      "local": "yes",
-      "name": "C++ compiler",
+      "local": "yes", 
+      "name": "C++ compiler", 
       "tags": "compiler,lang-cpp,llvm,v3.9.0-ck-package"
     }
-  },
+  }, 
   "end_full_path": {
-    "android": "lib$#sep#$SwPrefetchPass.so",
-    "linux": "lib/SwPrefetchPass.so",
-    "mingw": "lib\\SwPrefetchPass.so",
+    "android": "lib$#sep#$SwPrefetchPass.so", 
+    "linux": "lib/SwPrefetchPass.so", 
+    "mingw": "lib\\SwPrefetchPass.so", 
     "win": "lib\\SwPrefetchPass.so"
-  },
-  "process_script": "compile",
-  "soft_uoa": "cb5940a8eba4fe8b",
-  "suggested_path": "plugin-llvm-sw-prefetch-pass",
+  }, 
+  "need_cpu_info": "yes", 
+  "process_script": "compile", 
+  "soft_uoa": "cb5940a8eba4fe8b", 
+  "suggested_path": "plugin-llvm-sw-prefetch-pass", 
   "tags": [
-    "plugin",
-    "compiler-plugin",
-    "llvm",
+    "plugin", 
+    "compiler-plugin", 
+    "llvm", 
     "sw-prefetch-pass"
   ]
 }

--- a/package/plugin-llvm-sw-prefetch-pass/Makefile
+++ b/package/plugin-llvm-sw-prefetch-pass/Makefile
@@ -7,6 +7,7 @@ LLVM_DIR = /local/scratch/sa614/clang
 LLVM_BUILD_DIR = $(LLVM_DIR)/build
 CLANG_DIR = $(LLVM_DIR)/tools/clang
 CLANG = $(LLVM_BUILD_DIR)/bin/clang
+FORCE_USE_ABI=0
 
 # Compiler flags.
 CXXFLAGS  = -I$(LLVM_DIR)/include -I$(CLANG_DIR)/include -I$(LLVM_DIR)/llvm/include 
@@ -15,7 +16,7 @@ CXXFLAGS += ${EXTRA_FLAGS}
 CXXFLAGS += -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -Wno-long-long
 CXXFLAGS += -fPIC -fvisibility-inlines-hidden
 CXXFLAGS += -fno-exceptions -fno-rtti -std=c++11
-CXXFLAGS += -Wall -D_GLIBCXX_USE_CXX11_ABI=0
+CXXFLAGS += -Wall -D_GLIBCXX_USE_CXX11_ABI=${FORCE_USE_ABI}
 
 # Linker flags.
 LDFLAGS = -shared -Wl,-undefined,dynamic_lookup

--- a/package/plugin-llvm-sw-prefetch-pass/compile.sh
+++ b/package/plugin-llvm-sw-prefetch-pass/compile.sh
@@ -9,6 +9,15 @@
 
 cd $INSTALL_DIR
 
+if [ "$CK_FORCE_USE_ABI" == "" ] ; then
+ MACHINE=$(uname -m)
+ if [ "${MACHINE}" == "aarch64" ]; then
+  CK_FORCE_USE_ABI=0
+ else
+  CK_FORCE_USE_ABI=1
+ fi
+fi
+
 mkdir lib
 rm -f lib/SwPrefetchPass.so
 
@@ -31,7 +40,8 @@ make CXX=$CK_CXX \
      CLANG_DIR=${CK_ENV_COMPILER_LLVM} \
      CLANG=${CK_ENV_COMPILER_LLVM_BIN}/$CK_CC \
      EXTRA_FLAGS=${CK_EXTRA_FLAGS} \
-     PLUGIN_OUT=${CK_PLUGIN_OUT}
+     PLUGIN_OUT=${CK_PLUGIN_OUT} \
+     FORCE_USE_ABI=${CK_FORCE_USE_ABI}
 if [ "${?}" != "0" ] ; then
  echo "Error: Compilation failed in $PWD!" 
  exit 1


### PR DESCRIPTION
Hi Sam,

I added simple functionality to customize D_GLIBCXX_USE_CXX11_ABI. 


Rather than changing Makefile, if someone encounters an issue with  _ZNK4llvm12FunctionPass17createPrinterPassERNS_11raw_ostreamERKSs when compiling using Clang, they can then manually recompile packages (answering Y to all questions) with one of the following values:

$ ck install package:plugin-llvm-sw-prefetch-pass -DCK_FORCE_USE_ABI=0
$ ck install package:plugin-llvm-sw-prefetch-pass -DCK_FORCE_USE_ABI=1

$ ck install package:plugin-llvm-sw-prefetch-no-strides-pass -DCK_FORCE_USE_ABI=0
$ ck install package:plugin-llvm-sw-prefetch-no-strides-pass -DCK_FORCE_USE_ABI=1

If this var is not specified, CK build script will try to detect host machine and will set it to 1 on aarch64 and to 0 on anything else ...

Do you mind to check if it works fine. If yes, you can reflect it in the Troubleshooting section ...

Thanks!
